### PR TITLE
duplicate search result

### DIFF
--- a/src/datasources/documize.js
+++ b/src/datasources/documize.js
@@ -37,7 +37,9 @@ class DocumizeRestAPI extends RESTDataSource {
       keywords,
       ...searchOptions,
     });
-    return data.slice(0, limit).map(this.reduceDocumizeSearch.bind(this));
+    const uniqueSearchResult = _.uniqBy(data, 'documentId');
+
+    return uniqueSearchResult.slice(0, limit).map(this.reduceDocumizeSearch.bind(this));
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,5 +66,5 @@ const server = new ApolloServer({
 
 // This `listen` method launches a web-server.
 server.listen().then(({url}) => {
-  console.log(`🚀  RocketGate Rocket.Chat GraphQL search gateway ready at ${url}`);
+  console.log(`📖    Ducumize GraphQL search gateway ready at ${url}`);
 });


### PR DESCRIPTION
Use loadash to remove duplicate search result sent from Ducumize. 
The reason why it sent duplicate results is that it sent all matches in one document as the document itself.
